### PR TITLE
Add u.to to scams list

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -13,6 +13,7 @@
             "*https://extercheats.com/*",
             "https://rb.gy/zziey",
             "https://t.me/*",
+            "*u.to*",
             "*mega.nz*",
             "*nitro.cheap*",
             "nudes",


### PR DESCRIPTION
It's been used in fake steam card gift scams using masked links.