### PR TITLE
Add Gofile.io to scams

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -15,6 +15,7 @@
             "https://t.me/*",
             "*u.to*",
             "*mega.nz*",
+            "*gofile.io*",
             "*nitro.cheap*",
             "nudes",
             "*sc.link*",


### PR DESCRIPTION
I've seen it used before, NTTS has documented it too, cloud service used for sharing malware "games" for the "developer" scam.